### PR TITLE
Fix: 📝Adobe Legal requires contributors sign a CLA

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,9 +10,7 @@ This project adheres to the Adobe [code of conduct](CODE_OF_CONDUCT.md). By part
 
 ## Contributor License Agreement
 
-All third-party contributions to this project must be accompanied by a signed contributor license. This gives Adobe permission to redistribute your contributions as part of the project. A CLA process is coming soon!
-
-<!-- Sign our CLA at [SOME LINK](no link yet). You only need to submit an Adobe CLA one time, so if you have submitted one previously, you are probably good to go! -->
+All third-party contributions to this project must be accompanied by a signed contributor license. This gives Adobe permission to redistribute your contributions as part of the project. Sign our [CLA](http://opensource.adobe.com/cla.html). You only need to submit an Adobe CLA one time, so if you have submitted one previously, you are good to go!
 
 ## Code Reviews
 


### PR DESCRIPTION
### What does this PR do?

🎵 Adobe Legal requires that all external contribution authors sign Adobe's CLA 🎵 

### Checklist

- [x] I've read the [contribution guidelines](./CONTRIBUTING.md) and the [Code of Conduct](./CODE_OF_CONDUCT.md)
- [ ] An issue has been created for this PR
- [x] Title begins with one of the following: `Fix:`, `Update:`, `Breaking:`, or `New:`
- [ ] Title ends with a reference to the related issue(s): `(fixes #issue)` or `(refs #issue)`
- [x] Linting and unit tests all pass (`npm test`)
- [ ] PR includes new unit tests as necessary (or will be submitted as a separate PR)
- [ ] PR includes documentation as necessary (or will be forthcoming in a separate PR)
